### PR TITLE
Add SendGrid to CLI options

### DIFF
--- a/packages/@crystallize/cli/lib/template.js
+++ b/packages/@crystallize/cli/lib/template.js
@@ -81,8 +81,20 @@ const reactTemplateQuestions = [
         name: 'Use ZEIT Now (https://zeit.co/now) for deployments',
         value: 'useNow',
         checked: defaultOptions.react && defaultOptions.react.useNow
+      },
+      {
+        name: 'Use SendGrid (https://sendgrid.com) for emails',
+        value: 'useSendGrid',
+        checked: defaultOptions.react && defaultOptions.react.useSendGrid
       }
     ]
+  },
+  {
+    type: 'input',
+    name: 'sendGridApiKey',
+    message: 'SendGrid API Key (https://app.sendgrid.com/settings/api_keys)',
+    default: 'sendgrid',
+    when: answers => answers.options.find(option => option === 'useSendGrid')
   },
   {
     type: 'confirm',
@@ -134,13 +146,14 @@ const createReactProject = async (
 
   if (answers.saveDefaults) {
     logInfo('Saving default template preferences');
+    logInfo('Note: This will not save any tokens or keys');
     config.set('defaults.react', options);
   }
 
   const templateOptions = {
     tenantId,
-    useNow: options.useNow,
-    useTypescript: options.typescript
+    sendGridApiKey: answers.sendGridApiKey,
+    ...options
   };
 
   cloneRepository(boilerplates['react'], projectPath);

--- a/packages/@crystallize/react-scripts/scripts/init.js
+++ b/packages/@crystallize/react-scripts/scripts/init.js
@@ -48,7 +48,8 @@ const configureEnvironment = (projectPath, options) => {
     GTM_ID: '',
     CRYSTALLIZE_GRAPH_URL_BASE: 'https://graph.crystallize.com',
     CRYSTALLIZE_TENANT_ID: 'teddy-bear-shop',
-    SECRET: 'secret'
+    SECRET: 'secret',
+    SENDGRID_API_KEY: options.sendGridApiKey
   };
 
   if (options.tenantId) {
@@ -69,7 +70,10 @@ const configureEnvironment = (projectPath, options) => {
       'utf-8'
     );
     const nowJsonObj = JSON.parse(nowJson);
-    nowJsonObj.env = envVars;
+    nowJsonObj.env = {
+      ...envVars,
+      SENDGRID_API_KEY: '@sendgrid-api-key'
+    };
     fs.writeFileSync(
       path.resolve(projectPath, 'now.json'),
       JSON.stringify(nowJsonObj, null, 2) + os.EOL,


### PR DESCRIPTION
Allows SendGrid to be configured for sending emails in the React boilerplate.