### PR TITLE
Save sendgrid api key only when specified and add info around Now Secrets

### DIFF
--- a/packages/@crystallize/cli/lib/template.js
+++ b/packages/@crystallize/cli/lib/template.js
@@ -118,9 +118,10 @@ const reactTemplateQuestions = [
  */
 const createTemplateProject = async (projectName, projectPath, flags) => {
   const answers = await inquirer.prompt(rootQuestions);
+  const tenantId = answers.tenantId || 'teddy-bear-shop';
   const template = templates.find(t => t.value === answers.template);
   if (template.type === 'react') {
-    await createReactProject(projectName, projectPath, answers.tenantId, flags);
+    await createReactProject(projectName, projectPath, tenantId, flags);
   } else {
     logError(`Unknown template type: "${template.type}`);
     process.exit(1);
@@ -257,6 +258,23 @@ const showInstructions = (projectPath, useYarn, templateOptions) => {
       `Deploy to ZEIT Now (https://zeit.co/now) by running ${chalk.green(
         'now'
       )}`
+    );
+    console.log();
+    console.log(
+      `Note that you will need to manually add any secret api keys as a Now Secret. Secret names are defined in ${chalk.blue(
+        'now.json'
+      )}.`
+    );
+    console.log(
+      `You can do this by running ${chalk.green(
+        'now secrets add <secret-name> <secret-value>'
+      )}`
+    );
+    console.log();
+    console.log(
+      `See ${chalk.blue(
+        'https://zeit.co/docs/v2/serverless-functions/env-and-secrets'
+      )} for more details.`
     );
   }
 

--- a/packages/@crystallize/react-scripts/scripts/init.js
+++ b/packages/@crystallize/react-scripts/scripts/init.js
@@ -47,10 +47,13 @@ const configureEnvironment = (projectPath, options) => {
   const envVars = {
     GTM_ID: '',
     CRYSTALLIZE_GRAPH_URL_BASE: 'https://graph.crystallize.com',
-    CRYSTALLIZE_TENANT_ID: 'teddy-bear-shop',
-    SECRET: 'secret',
-    SENDGRID_API_KEY: options.sendGridApiKey
+    CRYSTALLIZE_TENANT_ID: options.tenantId,
+    SECRET: 'secret'
   };
+
+  if (options.sendGridApiKey) {
+    envVars.SENDGRID_API_KEY = options.sendGridApiKey;
+  }
 
   if (options.tenantId) {
     envVars.CRYSTALLIZE_TENANT_ID = options.tenantId;
@@ -70,10 +73,12 @@ const configureEnvironment = (projectPath, options) => {
       'utf-8'
     );
     const nowJsonObj = JSON.parse(nowJson);
-    nowJsonObj.env = {
-      ...envVars,
-      SENDGRID_API_KEY: '@sendgrid-api-key'
-    };
+    nowJsonObj.env = envVars;
+
+    if (options.sendGridApiKey) {
+      nowJsonObj.env.SENDGRID_API_KEY = '@sendgrid-api-key';
+    }
+
     fs.writeFileSync(
       path.resolve(projectPath, 'now.json'),
       JSON.stringify(nowJsonObj, null, 2) + os.EOL,


### PR DESCRIPTION
This correctly sets the SendGrid API key and makes a note to the user that they need to run `now secrets add sendgrid-api-key <key>` in order to deploy their site.

Also fixes an issue where the tenant id wasn't being set correctly.